### PR TITLE
Resign first responder before attempting to submit data

### DIFF
--- a/iGoat-Swift/iGoat-Swift/Source/Exercises/Server Communication/ServerCommunicationExerciseVC.swift
+++ b/iGoat-Swift/iGoat-Swift/Source/Exercises/Server Communication/ServerCommunicationExerciseVC.swift
@@ -23,6 +23,10 @@ class ServerCommunicationExerciseVC: UIViewController {
                            "socialSecurityNumber":ssnField.text]
         
         do {
+            //resign first responder before attempting to submit data. 
+            firstNameField.resignFirstResponder()
+            lastNameField.resignFirstResponder()
+            ssnField.resignFirstResponder()
             
             let jsonData = try JSONSerialization.data(withJSONObject: accountInfo, options: .prettyPrinted)
             var request = URLRequest(url: URL(string: serverCommunicationUserUrl)!)


### PR DESCRIPTION
This prevents the application from crashing when a UIAlert message attempts to display over the Keyboard.